### PR TITLE
Update data-store-variables-and-jms-queues-when-to-use-which-option-6…

### DIFF
--- a/docs/ci/Development/data-store-variables-and-jms-queues-when-to-use-which-option-6bc21cb.md
+++ b/docs/ci/Development/data-store-variables-and-jms-queues-when-to-use-which-option-6bc21cb.md
@@ -51,7 +51,7 @@ JMS queue
 </td>
 <td valign="top">
 
-You can use the JMS sender adapter to store messages in a JMS queue. One important key characteristic of the Java Message Service \(JMS\) feature is the support of high-speed messaging with high throughput. This is why it offers the optimal solution for reliable messaging using asynchronous decoupling. JMS is a Java-based standard application programming interface \(API\) for sending and receiving messages. It enables efficient asynchronous communication based on a JMS message broker between different components. The JMS message broker is a separate runtime component that ensures that messages in JMS queues in the JMS message broker are treated separately. The JMS adapter is used to store messages in the JMS queue and to consume messages from the JMS queue in the JMS message broker.
+You can use the JMS receiver adapter to store messages in a JMS queue. One important key characteristic of the Java Message Service \(JMS\) feature is the support of high-speed messaging with high throughput. This is why it offers the optimal solution for reliable messaging using asynchronous decoupling. JMS is a Java-based standard application programming interface \(API\) for sending and receiving messages. It enables efficient asynchronous communication based on a JMS message broker between different components. The JMS message broker is a separate runtime component that ensures that messages in JMS queues in the JMS message broker are treated separately. The JMS adapter is used to store messages in the JMS queue and to consume messages from the JMS queue in the JMS message broker.
 
 The processing sequence used by the JMS adapter is first-in, first-out \(FIFO\). However, because of parallel processing and retry handling this does not mean that messages are processed in a guaranteed order.
 
@@ -122,7 +122,7 @@ What is the frequency of consumption?
 </td>
 <td valign="top">
 
-Whenever a message is initiated by a client's call or a timer \(scheduler\)
+Whenever a message is initiated by a client's call or a timer \(scheduler\), or pushed to the integration flow automatically by the Data Store sender adapter.
 
 </td>
 <td valign="top">


### PR DESCRIPTION
Hi SAP Team, 

In general this documentation doesn't mention the Data Store Sender adapter. I don't remember, but I think this adapter is relatively new - so I guess that's the reason. With the availability of the DS Sender adapter, in my opinion, most of the disadvantages compared to the JMS adapter are eliminated. Or am I missing something? 
In respect of this, also the Async decoupling usecases explained here: https://help.sap.com/docs/cloud-integration/sap-cloud-integration/use-cases-for-data-store-and-variables need to be adjusted as no (timer based) polling is needed anymore. 

Kinds regards, 
Philippe