### PR TITLE
Update access-header-and-properties-in-xpath-996ce78.md

### DIFF
--- a/docs/ci/Development/access-header-and-properties-in-xpath-996ce78.md
+++ b/docs/ci/Development/access-header-and-properties-in-xpath-996ce78.md
@@ -100,7 +100,7 @@ XPath
 </td>
 <td valign="top">
 
-java.lang.String
+java.lang.Number
 
 </td>
 <td valign="top">


### PR DESCRIPTION
java.lang.Number is the correct Data Type for MaxPrice as it is in integer. And the earlier data type mentioned java.lang.String will be not work in Message Filter where the property MaxPrice is invoked for filtering the reply received from ESPM.

<!-------------------------------------------------------------------------------------------
Note that this proposal is visible on github.com for anyone to see.
Refrain from sharing sensitive information.
-------------------------------------------------------------------------------------------->

