### PR TITLE
Fix typo in File Name description of FTP receiver adapter.

### DIFF
--- a/docs/ci/Development/configure-the-ftp-receiver-adapter-c16d331.md
+++ b/docs/ci/Development/configure-the-ftp-receiver-adapter-c16d331.md
@@ -129,7 +129,7 @@ Name of the file to be written.
 You can configure this parameter by entering a dynamic expression such like `${property.property_name}` or `${header.header_name}` \(see: [Dynamically Configure Integration Flow Parameters](dynamically-configure-integration-flow-parameters-fff5b2a.md)\).
 
 > ### Note:  
-> If you don’t enter a file name and the parameter remains blank, the content of the `CamelFileName` header isn’tused as file name. If this header is specified, the Exchange ID is used as file name.
+> If you don’t enter a file name and the parameter remains blank, the content of the `CamelFileName` header is used as file name. If this header is specified, the Exchange ID is used as file name.
 
 The endpoint URL that is actually used at runtime is displayed in the message processing log \(MPL\) in the message monitoring application \(MPL property `ProduceFile`\). Note that you can manually configure the endpoint URL using the *FileName* attribute of the FTP adapter. However, you can dynamically override the value of this attribute by using the Camel header `CamelFileName`.
 


### PR DESCRIPTION
If the "File Name" parameter is left BLANK then the FTP receiver adapter uses the value of the header parameter `CamelFileName`.
The documentation describes it as if it would work exactly the opposite way.

Typo: "isn't" <> "is"
