### PR TITLE
Add documentation for default headers

### DIFF
--- a/docs/ci/Development/configure-the-amqp-sender-adapter-99ce674.md
+++ b/docs/ci/Development/configure-the-amqp-sender-adapter-99ce674.md
@@ -2,8 +2,49 @@
 
 # Configure the AMQP Sender Adapter
 
-You use the Advanced Message Queuing Protocol \(AMQP\) sender adapter to consume messages in SAP Cloud Integration from queues or topic subscriptions in an external message broker.
+You use the Advanced Message Queuing Protocol \(AMQP\) sender adapter to consume messages in SAP Cloud Integration from queues or topic subscriptions in an external message broker or from the SAP Event Mesh.
 
+## Default Headers
+
+Each time an Iflow is triggered via this Adapter the following Headers are present:
+
+*Headers have to be listed in Allowed Header(s) for Iflow*
+<table>
+<tr>
+<th valign="top">
+
+Header
+
+</th>
+<th valign="top">
+
+Description
+
+</th></tr>
+<tr>
+<td valign="top">
+
+*JMSRedelivered*
+
+</td>
+<td valign="top">
+
+Indicates if the message is retried. Values: true/false
+
+</td>
+</tr>
+<td valign="top">
+
+*JMSXDeliveryCount*
+
+</td>
+<td valign="top">
+
+The count of how often the Message is retried. First Read has Count 0.
+
+</td>
+</tr>
+</table>
 
 
 > ### Note:  
@@ -23,6 +64,9 @@ You use the Advanced Message Queuing Protocol \(AMQP\) sender adapter to consume
 
 > ### Note:  
 > This adapter exchanges data with a remote component that might be outside the scope of SAP. Make sure that the data exchange complies with your company’s policies.
+
+> ### Note:
+> There is no option to configure a delay in retry processing in the AMQP adapter because this is not supported by the AMQP protocol. 
 
 
 

--- a/docs/ci/Development/data-store-sender-adapter-4f5ef3f.md
+++ b/docs/ci/Development/data-store-sender-adapter-4f5ef3f.md
@@ -16,6 +16,45 @@ You can model the steps that write into the data store and those that consume me
 
 If multiple worker nodes are set up, there's no parallel processing of the same data store entry by these multiple worker nodes.
 
+## Default Headers
+Each time an Iflow is triggered via this Adapter the following Headers are present:
+
+*Headers have to be listed in Allowed Header(s) for Iflow*
+<table>
+<tr>
+<th valign="top">
+
+Header
+
+</th>
+<th valign="top">
+
+Description
+
+</th></tr>
+<tr>
+<td valign="top">
+
+*SAP_DataStoreRetries*
+
+</td>
+<td valign="top">
+The count of how often the Message is retried. First Read has Count 0.
+</td>
+</tr>
+<td valign="top">
+
+*SAP_MessageProcessingLogID*
+
+</td>
+<td valign="top">
+
+The ID of the entry. Can be used for update or delete actions. See: [Define Data Store Operations](define-data-store-operations-79f63a4.md)
+
+</td>
+</tr>
+</table>
+
 > ### Tip:  
 > You can use this feature to implement scenarios with quality of service Exactly Once for cases when the sender hasn't any mechanism in place to retry messages.
 > 
@@ -200,4 +239,5 @@ Enter a value for the timeout of the in-progress repository. After this time, a 
 </td>
 </tr>
 </table>
+
 


### PR DESCRIPTION
Add documentation for default headers in data-store-adapter and amqp-sender-adapter.

Based on the following documentation:
Data-Store:
https://community.sap.com/t5/technology-blog-posts-by-members/automating-message-retries-in-sap-cpi-with-the-data-store-channel/ba-p/14024305

Amqp:
https://community.sap.com/t5/integration-blog-posts/cloud-integration-connecting-to-messaging-systems-using-the-amqp-adapter/ba-p/13419906


