### PR TITLE
Fix typo in runtime configuration documentation

### DIFF
--- a/docs/ISuite/50-Development/specify-the-runtime-configuration-0c1c96e.md
+++ b/docs/ISuite/50-Development/specify-the-runtime-configuration-0c1c96e.md
@@ -113,7 +113,7 @@ Specify the runtime properties of the integration flow.
     > 
     >     Note that contants separated with the pipe character \(`|`\) \(as mentioned above\) is also a regular expression.
     > 
-    >     You can also combine contant values with regular expressions, separated by the pipe character \(`|`\).
+    >     You can also combine constant values with regular expressions, separated by the pipe character \(`|`\).
     > 
     >     Example: `AB_[0-9]|ABC`
     > 


### PR DESCRIPTION
Constant spelling was wrong

<!-------------------------------------------------------------------------------------------
Note that this proposal is visible on github.com for anyone to see.
Refrain from sharing sensitive information.
-------------------------------------------------------------------------------------------->

