### PR TITLE
fix: remove repeated word 'The the' in permissions-eaa8779.md

### DIFF
--- a/docs/ISuite/50-Development/permissions-eaa8779.md
+++ b/docs/ISuite/50-Development/permissions-eaa8779.md
@@ -8,7 +8,7 @@
 
 ## Permissions
 
-The the role template `AuthGroup_TenantPartnerDirectoryConfigurator` grants permissions to access \(read and write\) the Partner Directory.
+The role template `AuthGroup_TenantPartnerDirectoryConfigurator` grants permissions to access \(read and write\) the Partner Directory.
 
 More information:
 

--- a/docs/ci/Development/permissions-eaa8779.md
+++ b/docs/ci/Development/permissions-eaa8779.md
@@ -8,7 +8,7 @@
 
 ## Permissions, Cloud Foundry Environment
 
-The the role template `AuthGroup_TenantPartnerDirectoryConfigurator` grants permissions to access \(read and write\) the Partner Directory.
+The role template `AuthGroup_TenantPartnerDirectoryConfigurator` grants permissions to access \(read and write\) the Partner Directory.
 
 More information:
 


### PR DESCRIPTION
## Summary

Fixes #207

The sentence about the `AuthGroup_TenantPartnerDirectoryConfigurator` role template begins with `The the` (duplicated article). Both copies of the file had this error:

- `docs/ci/Development/permissions-eaa8779.md`
- `docs/ISuite/50-Development/permissions-eaa8779.md`

**Before:** `The the role template `AuthGroup_TenantPartnerDirectoryConfigurator` grants...`
**After:** `The role template `AuthGroup_TenantPartnerDirectoryConfigurator` grants...`